### PR TITLE
Increase the visibility of logstash variable names

### DIFF
--- a/syntax/logstash.vim
+++ b/syntax/logstash.vim
@@ -9,8 +9,8 @@ setlocal iskeyword+=.
 setlocal iskeyword+=/
 setlocal iskeyword+=:
 
-syn match logstashVariableBlock '\[[^,]*\]' contained
-syn match logstashVariableString '\[[^,]*\]' contained
+syn match logstashVariableBlock '\[[^,]*\]' contains=logstashFormat
+syn match logstashVariableString '\[[^,]*\]' contains=logstashFormat
 
 syn match logstashOperator '=>' contained
 syn match logstashOperator '==' contained

--- a/syntax/logstash.vim
+++ b/syntax/logstash.vim
@@ -35,6 +35,7 @@ syn region logstashBlock start=+{+ end=+}+ contains=logstashBlock,logstashCommen
 syn region logstashString start=+"+ end=+"+ skip=+\\\\\|\\"+ contains=logstashVariableString,logstashFormat oneline
 syn region logstashString start=+'+ end=+'+ skip=+\\\\\|\\'+ contains=logstashVariableString,logstashFormat oneline
 syn region logstashFormat start=+%{+ end=+}+ contains=logstashVariableString oneline
+syn region logstashFormat start=+<+ end=+>+ contains=logstashVariableString oneline
 
 syn match logstashComment ' *#.*$'
 


### PR DESCRIPTION
Hi, thanks for this handy vim syntax file :-)

The two diffs here fix a couple of cases where highlighting variable names wasn't happening. Lines 12,13 allow a %{VARIABLE} to be highlighted even when wrapped in [], which happens in my patterns a lot.

The other change highlights <field> names, usually seen in the ad-hoc regex format (?&lt;field>regexp) syntax used as an alternative to %{PATTERN:field} (i.e. where your regexp isn't important enough to be included in your pattern definitions)
